### PR TITLE
PARSE-2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ const skillNames = [
  * Parses player's data from an individual player's page.
  * @return Player the player
  */
-const parsePlayer = (): Player => {
+export const parsePlayer = (): Player => {
   /*
    * Get the player's page main elements by selecting the div siblings of #main-1 (which is actually the skillsEl).
    * Note that some div siblings are ignored, hence the extra commas in below destructuring.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ES6",                                     /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
- Compile to ES6 module instead of CommonJS
- parsePlayer is also a named export